### PR TITLE
Improve lilypad rendering

### DIFF
--- a/src/main/kotlin/mods/betterfoliage/client/render/RenderLilypad.kt
+++ b/src/main/kotlin/mods/betterfoliage/client/render/RenderLilypad.kt
@@ -11,14 +11,18 @@ import mods.octarinecore.client.render.Rotation
 import mods.octarinecore.client.render.alwaysRender
 import mods.octarinecore.client.render.modelRenderer
 import mods.octarinecore.client.render.noPost
+import mods.octarinecore.client.render.renderBlocks
 import net.minecraft.client.renderer.RenderBlocks
 import net.minecraftforge.common.util.ForgeDirection
 import org.apache.logging.log4j.Level
 
 class RenderLilypad : AbstractBlockRenderingHandler(BetterFoliageMod.MOD_ID) {
 
+    val lilypadHeight = 0.015625
+
     val rootModel = model {
         verticalRectangle(x1 = -0.5, z1 = 0.5, x2 = 0.5, z2 = -0.5, yBottom = -1.5, yTop = -0.5)
+            .move(lilypadHeight to ForgeDirection.UP)
             .setFlatShader(FlatOffsetNoColor(Int3.zero))
             .toCross(ForgeDirection.UP)
             .addAll()
@@ -26,7 +30,7 @@ class RenderLilypad : AbstractBlockRenderingHandler(BetterFoliageMod.MOD_ID) {
     val flowerModel = model {
         verticalRectangle(x1 = -0.5, z1 = 0.5, x2 = 0.5, z2 = -0.5, yBottom = 0.0, yTop = 1.0)
             .scale(0.5)
-            .move(0.5 to ForgeDirection.DOWN)
+            .move(0.5 - lilypadHeight to ForgeDirection.DOWN)
             .setFlatShader(FlatOffsetNoColor(Int3.zero))
             .toCross(ForgeDirection.UP)
             .addAll()
@@ -46,7 +50,14 @@ class RenderLilypad : AbstractBlockRenderingHandler(BetterFoliageMod.MOD_ID) {
         Config.blocks.lilypad.matchesID(ctx.block)
 
     override fun render(ctx: BlockContext, parent: RenderBlocks): Boolean {
-        if (renderWorldBlockBase(parent, face = alwaysRender)) return true
+        if (renderWorldBlockBase(
+                parentRenderer = parent,
+                face = alwaysRender,
+                block = { renderBlocks.renderBlockLilyPad(ctx.block, ctx.x, ctx.y, ctx.z) },
+            )
+        ) {
+            return true
+        }
 
         val rand = ctx.semiRandomArray(5)
         modelRenderer.render(

--- a/src/main/kotlin/mods/octarinecore/client/render/RenderBlocks.kt
+++ b/src/main/kotlin/mods/octarinecore/client/render/RenderBlocks.kt
@@ -87,6 +87,24 @@ class ExtendedRenderBlocks : RenderBlocks() {
         saveBottomLeft(face, faceCorners[face.ordinal].bottomLeft)
         saveBottomRight(face, faceCorners[face.ordinal].bottomRight)
     }
+
+    /** Lilypad rendering does not use any 'renderFace...' methods, so we capture AO for it separately */
+    override fun renderBlockLilyPad(block: Block?, x: Int, y: Int, z: Int): Boolean {
+        val icon = if (this.hasOverrideBlockTexture()) overrideBlockTexture else this.getBlockIconFromSide(block, 1)
+
+        return captureLilyPadFaceAO(ForgeDirection.DOWN, icon) &&
+            captureLilyPadFaceAO(ForgeDirection.UP, icon) &&
+            super.renderBlockLilyPad(block, x, y, z)
+    }
+
+    private fun captureLilyPadFaceAO(face: ForgeDirection, icon: IIcon): Boolean {
+        if (capture.isCorrectPass(face)) {
+            saveAllShading(face)
+            capture.icons[face.ordinal] = icon
+        }
+
+        return capture.renderCallback(capture, face, capture.passes[face.ordinal], icon)
+    }
 }
 
 /** Captures the AO values and textures used in a specific rendering pass when rendering a block. */


### PR DESCRIPTION
- Render lilypad top and bottom at the same height (like vanilla does)

- Properly align root and flower to lilypad body

- Fix side face render issues when using FalseTweaks + Beddium

Before:
<img width="1920" height="1052" alt="before" src="https://github.com/user-attachments/assets/a75ef546-df9a-43f1-80ba-bff9e96a0a41" />


After:
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/1fc4a6bb-1a4a-4e00-b091-32c3b08b5564" />

Fixes https://github.com/Kynake/BetterFoliage/issues/16