### PR TITLE
feat: Migrate to LegacyModdingMC Forgelin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:Forgelin:2.0.3-GTNH")
+    api("com.falsepattern:forgelin-mc1.7.10:2.4.0-2.2.21:dev")
     compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.122:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.12-GTNH:dev") { transitive = false }
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev") { transitive = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -200,3 +200,4 @@ customArchiveBaseName = BetterFoliage-LegacyEdition
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
+kotlin.stdlib.default.dependency=false

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,4 +1,9 @@
 // Add any additional repositories for your dependencies here.
 
 repositories {
+    //LegacyModdingMC Forgelin
+    maven {
+        name = "mavenpattern"
+        url = "https://mvn.falsepattern.com/releases/"
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/Kynake/BetterFoliage/issues/20

`kotlin.stdlib.default.dependency=false` in gradle.properties prevents the Kotlin stdlib from being added to the classpath twice on runClient/runServer (also happens with GTNH forgelin)